### PR TITLE
Simplify canonical.js

### DIFF
--- a/canonical.js
+++ b/canonical.js
@@ -2,18 +2,11 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   const canonical = document.querySelector('link[rel="canonical"]');
-  if (canonical && canonical.href) {
-    if (location.href === canonical.href) {
-      chrome.runtime.sendMessage({
-        method: 'is-canonical',
-        url: canonical.href
-      });
-    }
-    else {
-      chrome.runtime.sendMessage({
-        method: 'offer-canonical',
-        url: canonical.href
-      });
-    }
+  if (!canonical || !canonical.href) {
+    return
   }
+  chrome.runtime.sendMessage({
+    method: `${location.href === canonical.href ? 'is' : 'offer'}-canonical`,
+    url: canonical.href
+  });
 });


### PR DESCRIPTION
As discussed in #4 half a year back.

Not sure it’s worth it as it adds 2 more permissions, though probably not more scary than “access all your data for all websites”. At least code is simple and remains auditable easily. Also I still like the idea but I must say that I usually just click the canonical icon to go to the canonical page, then copy from the address bar, so the use case is not very strong either.

You can probably build a non-released beta version from addons.mozilla.org to see what it prompts for when installing it.