### PR TITLE
Copy canonical link

### DIFF
--- a/background.js
+++ b/background.js
@@ -33,3 +33,19 @@ chrome.pageAction.onClicked.addListener(tab => {
     }`
   });
 });
+
+chrome.contextMenus.create({
+  id: 'copy-canonical',
+  title: 'Copy canonical link',
+  contexts: ["page_action"]
+});
+
+chrome.contextMenus.onClicked.addListener(({ menuItemId }, tab) => {
+  if (menuItemId === 'copy-canonical') {
+  chrome.tabs.executeScript(tab.id, {
+    code: `{
+      navigator.clipboard.writeText(document.querySelector('link[rel="canonical"]').href);
+    }`
+  });
+  }
+})

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,9 @@
   },
 
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "clipboardWrite",
+    "contextMenus"
   ],
 
   "content_scripts": [{


### PR DESCRIPTION
As discussed in #4 half a year back (description copied from #6 which had wrong origin branch).

Not sure it’s worth it as it adds 2 more permissions, though probably not more scary than “access all your data for all websites”. At least code is simple and remains auditable easily. Also I still like the idea but I must say that I usually just click the canonical icon to go to the canonical page, then copy from the address bar, so the use case is not very strong either.

You can probably build a non-released beta version from addons.mozilla.org to see what it prompts for when installing it.
